### PR TITLE
global.scssにメインで使うul,li.aタグのスタイルを追加

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -3,3 +3,13 @@
 body {
   background-color: $mainBgColor;
 }
+
+ul,
+li {
+  list-style: none;
+}
+
+li a {
+  color: $subBgColor;
+  text-decoration: none;
+}


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->
https://d-base-hp.atlassian.net/jira/software/projects/SCRUM/boards/1?assignee=712020%3Aeaa8c0e2-9e3c-447d-bc16-131ef7fc446d&selectedIssue=SCRUM-148
## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
 - [x] global.scssにデフォルトの設定を追加
 - [x] ul.li.aタグのデフォルト設定追加
## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
