### PR TITLE
node.jsの指定を20xのlatestに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "*.{ts,tsx}": "bash -c tsc --noEmit"
   },
   "engines": {
-    "node": "21.7.1",
+    "node": "20.18.0",
     "pnpm": "9.12.3"
   }
 }


### PR DESCRIPTION
## チケット

なし

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと

vercelのdeploy error解消のため、以下対応した

- package.jsonのenginesでnode.jsの指定を20xのlatestに変更

@gakki-san @takomaru2 おのおのローカルのnode.jsのバージョンを20.18.0に変更してください


## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
