### PR TITLE
node, pnpmのバージョン固定をmajarのみに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "*.{ts,tsx}": "bash -c tsc --noEmit"
   },
   "engines": {
-    "node": "20.18.0",
-    "pnpm": "9.12.3"
+    "node": "20.x",
+    "pnpm": "9.x"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと

vercelでpnpm iによるdeploy errorが出ていたため。

## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
