### PR TITLE
ストーリーブックにモバイルとデスクトップのビューポートを追加 

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,6 +10,7 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
+    '@storybook/addon-viewport',
   ],
   framework: {
     name: '@storybook/nextjs',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -25,7 +25,26 @@ const preview: Preview = {
         },
       ],
     },
+    viewport: {
+      viewports: {
+        desktop: {
+          name: 'Desktop',
+          styles: {
+            width: '1680px',
+            height: '1080px',
+          },
+        },
+        mobile: {
+          name: 'Mobile',
+          styles: {
+            width: '375px',
+            height: '667px',
+          },
+        },
+      },
+    },
   },
+
   decorators: [
     (Story) => (
       <>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@storybook/addon-essentials": "^8.4.2",
     "@storybook/addon-interactions": "^8.4.2",
     "@storybook/addon-onboarding": "^8.4.2",
+    "@storybook/addon-viewport": "^8.4.7",
     "@storybook/blocks": "^8.4.2",
     "@storybook/nextjs": "^8.4.2",
     "@storybook/react": "^8.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@storybook/addon-onboarding':
         specifier: ^8.4.2
         version: 8.4.2(react@18.3.1)(storybook@8.4.2(prettier@3.3.3))
+      '@storybook/addon-viewport':
+        specifier: ^8.4.7
+        version: 8.4.7(storybook@8.4.2(prettier@3.3.3))
       '@storybook/blocks':
         specifier: ^8.4.2
         version: 8.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.2(prettier@3.3.3))
@@ -1467,6 +1470,11 @@ packages:
     resolution: {integrity: sha512-qVQ2UaxCNsUSFHnAAAizNPIJ/QwfMg7p5bBdpYROTZXJe+bxVp0rFzZmQgHZ3/sn+lzE4ItM4QEfxkfQUWi1ag==}
     peerDependencies:
       storybook: ^8.4.2
+
+  '@storybook/addon-viewport@8.4.7':
+    resolution: {integrity: sha512-hvczh/jjuXXcOogih09a663sRDDSATXwbE866al1DXgbDFraYD/LxX/QDb38W9hdjU9+Qhx8VFIcNWoMQns5HQ==}
+    peerDependencies:
+      storybook: ^8.4.7
 
   '@storybook/blocks@8.4.2':
     resolution: {integrity: sha512-yAAvmOWaD8gIrepOxCh/RxQqd/1xZIwd/V+gsvAhW/thawN+SpI+zK63gmcqAPLX84hJ3Dh5pegRk0SoHNuDVA==}
@@ -6711,6 +6719,11 @@ snapshots:
       storybook: 8.4.2(prettier@3.3.3)
 
   '@storybook/addon-viewport@8.4.2(storybook@8.4.2(prettier@3.3.3))':
+    dependencies:
+      memoizerific: 1.11.3
+      storybook: 8.4.2(prettier@3.3.3)
+
+  '@storybook/addon-viewport@8.4.7(storybook@8.4.2(prettier@3.3.3))':
     dependencies:
       memoizerific: 1.11.3
       storybook: 8.4.2(prettier@3.3.3)


### PR DESCRIPTION
## チケット


<!-- チケットのリンク -->

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
ストーリーブックを使用している時に開発者モードで画面のpx指定をするのが面倒だったのでインストールしてみた

## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
