### PR TITLE
 fix useWindowWidth globalthis

### DIFF
--- a/src/hooks/useWindowWidth.ts
+++ b/src/hooks/useWindowWidth.ts
@@ -1,16 +1,15 @@
 import { useState, useEffect } from 'react';
 
 export const useWindowWidth = () => {
-  const [windowWidth, setWindowWidth] = useState<number>(
-    typeof globalThis === 'undefined' ? 375 : globalThis.window.innerWidth,
-  );
+  const [windowWidth, setWindowWidth] = useState<number>(375);
 
   useEffect(() => {
-    const handleResize = () => setWindowWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
+    const updateWidth = () => setWindowWidth(window.innerWidth);
+    updateWidth();
 
+    window.addEventListener('resize', updateWidth);
     return () => {
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('resize', updateWidth);
     };
   }, []);
 


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
- build時に画面幅を取得するglobalthisでserver errorが出ていた。
- globalthisを使わずに、useEffectにまとめることで解決
## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
