### PR TITLE
 Changed the style of the xl-sized slideImage

### DIFF
--- a/src/pages/top/components/TopViewAutoImageSlide/index.module.scss
+++ b/src/pages/top/components/TopViewAutoImageSlide/index.module.scss
@@ -7,6 +7,10 @@
   right: 0;
   height: 100vh;
   object-fit: cover;
+
+  @include xl {
+    object-fit: fill;
+  }
 }
 
 .imageVisible {


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
- topView SlideImageのアニメーションで、画像がスライドしてきた時に、最後微妙に大きくなるというなぞの挙動があったのを修正
- 無修正

https://github.com/user-attachments/assets/79c746ff-a044-48e9-a00b-10afcd509a5f

- 修正後

https://github.com/user-attachments/assets/c4e1a3ed-b5d0-4b76-abc6-c260aa2af1fb


## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
