### PR TITLE
styled min-width of beforeafter card

### DIFF
--- a/src/components/BeforeAfterSpCard/index.module.scss
+++ b/src/components/BeforeAfterSpCard/index.module.scss
@@ -22,6 +22,7 @@
   flex: 1;
   flex-basis: 20%;
   flex-direction: column;
+  min-width: 92px;
   padding-inline: linear-clamp(12, 18);
   font-family: $mainFontEN;
   font-size: linear-clamp(16, 30);


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
- カードtitleのwidthがbeforeとafterで違ったので調整
- 修正前
![スクリーンショット 2025-01-25 15 27 47](https://github.com/user-attachments/assets/8689cfe2-f84e-4e63-8b94-a1c823adb962)
- 修正後
![スクリーンショット 2025-01-25 15 29 26](https://github.com/user-attachments/assets/3b315e28-c1fe-4d58-88c7-2714944e8e95)

## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
