### PR TITLE
fixed close animation of header nav menu

### DIFF
--- a/src/components/Header/index.module.scss
+++ b/src/components/Header/index.module.scss
@@ -27,12 +27,10 @@
 }
 
 .spNavMenu.open {
-  opacity: 1;
   transform: translateX(0);
 }
 
 .spNavMenu.closed {
-  opacity: 0;
   transform: translateX(-100%);
 }
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -22,7 +22,7 @@ export const Header: FC = () => {
             isOpenMenu ? styles.open : styles.closed
           }`}
         >
-          {isOpenMenu && <SpNavMenu close={close} />}
+          <SpNavMenu close={close} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
- headernavmenuのclose時のアニメーションが効いていなかったので、修正。
- 効いていない理由としては、navmenuがアンマウントされてしまうためcssが効いていなかった。
- 解決策として、アンマウントされないようにした。パフォーマンス的に良くなかったら、また修正が必要かもだけどおそらく問題ないでしょうとのこと。

## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
