### PR TITLE
fixed header nav menu

### DIFF
--- a/src/components/Header/index.module.scss
+++ b/src/components/Header/index.module.scss
@@ -21,13 +21,12 @@
   top: 0;
   right: 0;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   transition: transform 0.3s ease-in-out;
   transform: translateX(100%);
 }
 
 .spNavMenu.open {
-  height: 100vh;
   transform: translateX(0);
 }
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import { Logo } from '../Logo';
 import styles from './index.module.scss';
-import { FC, useEffect } from 'react';
+import { FC } from 'react';
 import { SpNavMenu } from '../SpNavMenu';
 import { PcNavMenu } from '../PcNavMenu';
 import { useIsBoolean } from '@/hooks/useBoolean';
@@ -8,20 +8,22 @@ import { useIsBoolean } from '@/hooks/useBoolean';
 export const Header: FC = () => {
   const [isOpenMenu, { on: open, off: close }] = useIsBoolean();
 
-  useEffect(() => {
-    if (isOpenMenu) {
-      document.body.classList.add('noScroll');
-    } else {
-      document.body.classList.remove('noScroll');
-    }
-  }, [isOpenMenu]);
+  const handleOpenMenu = () => {
+    open();
+    document.body.classList.add('noScroll');
+  };
+
+  const handleCloseMenu = () => {
+    close();
+    document.body.classList.remove('noScroll');
+  };
   return (
     <div className={styles.container}>
       <div className={styles.logo}>
         <Logo color="white" isTopPageLink={true} />
       </div>
       <div className={styles.menu}>
-        <button className={styles.spMenu} onClick={open}>
+        <button className={styles.spMenu} onClick={handleOpenMenu}>
           MENU
         </button>
         <PcNavMenu />
@@ -30,7 +32,7 @@ export const Header: FC = () => {
             isOpenMenu ? styles.open : styles.closed
           }`}
         >
-          <SpNavMenu close={close} />
+          <SpNavMenu close={handleCloseMenu} />
         </div>
       </div>
     </div>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,12 +1,20 @@
 import { Logo } from '../Logo';
 import styles from './index.module.scss';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { SpNavMenu } from '../SpNavMenu';
 import { PcNavMenu } from '../PcNavMenu';
 import { useIsBoolean } from '@/hooks/useBoolean';
 
 export const Header: FC = () => {
   const [isOpenMenu, { on: open, off: close }] = useIsBoolean();
+
+  useEffect(() => {
+    if (isOpenMenu) {
+      document.body.classList.add('noScroll');
+    } else {
+      document.body.classList.remove('noScroll');
+    }
+  }, [isOpenMenu]);
   return (
     <div className={styles.container}>
       <div className={styles.logo}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -17,6 +17,7 @@ export const Header: FC = () => {
     close();
     document.body.classList.remove('noScroll');
   };
+
   return (
     <div className={styles.container}>
       <div className={styles.logo}>

--- a/src/components/SpNavMenu/index.module.scss
+++ b/src/components/SpNavMenu/index.module.scss
@@ -20,7 +20,11 @@
   position: absolute;
   top: 50%;
   right: linear-clamp(10, 20);
-  padding: 11px 18px 11px 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
   background-color: $colorWhite;
   border-radius: 3px;
   transform: translate(-50%, -50%);

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -6,6 +6,10 @@ body {
   background-color: $colorBlack;
 }
 
+.noScroll {
+  overflow: hidden;
+}
+
 ul,
 li {
   list-style: none;


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->

## デザイン

- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
- not possive top page scroll when open header nav menu
-  styled navmenu height when close navmenu 

## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
