### PR TITLE
Feature/restyled header back ground

### DIFF
--- a/src/components/Logo/index.module.scss
+++ b/src/components/Logo/index.module.scss
@@ -4,6 +4,7 @@
 .heading {
   font-family: $mainFontEN;
   font-size: linear-clamp(20, 40);
+  text-shadow: 2px 2px 4px $colorBlack;
 
   @include letterSpacing10(20px);
 }

--- a/src/components/PcNavMenu/index.module.scss
+++ b/src/components/PcNavMenu/index.module.scss
@@ -12,6 +12,7 @@
     column-gap: linear-clamp(5, 60);
     align-items: center;
     height: 100%;
+    text-shadow: 2px 2px 4px $colorBlack;
   }
 
   .menuItem {

--- a/src/pages/top/index.module.scss
+++ b/src/pages/top/index.module.scss
@@ -6,7 +6,6 @@
   inset: 0 0 auto;
   z-index: 100;
   padding-inline: linear-clamp(25, 70);
-  background-color: $colorBlack;
 }
 
 .fixedBottom {


### PR DESCRIPTION
## チケット

<!-- チケットのリンク -->


## デザイン
![スクリーンショット 2025-02-03 12 51 30](https://github.com/user-attachments/assets/8566c5eb-5a6d-49c9-8286-2e934b585502)
- [figma sp](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=2182-67&node-type=frame&t=cgU0zvzGt6y8MLjW-0)
- [figma pc](https://www.figma.com/design/jBNwr5G4kHTNgVg58svBZT/Garage-HP-Design-PC%26Mobile?node-id=1151-47&node-type=frame&t=cgU0zvzGt6y8MLjW-0)

## やったこと
- headerの背景色の削除
- Logoテキストのshadow追加
## やっていないこと

<!-- このPRではやらないことを明示する場合は記載しましょう -->
